### PR TITLE
Add playback-speed compensation for audio queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ public async Task<TrackData?> GetBestMatchForSong(string file)
     return queryResult.BestMatch?.Audio.Track;
 }
 ```
+
+#### Querying audio captured with vinyl-style pitch control
+
+When the source playback-speed change is known, pass its percentage together
+with the query samples. Positive values mean the source was played faster and
+negative values mean it was played slower. The query is resampled back to its
+original playback rate before fingerprinting.
+
+```csharp
+var queryResult = await QueryCommandBuilder.Instance.BuildQueryCommand()
+    .From(audioSamples, sourcePlaybackSpeedPercentage: 8)
+    .UsingServices(modelService)
+    .Query();
+```
+
+This supports vinyl-style pitch control, where tempo and pitch change together.
+It does not support pitch-only processing such as key lock. If the percentage is
+unknown, applications can try a small set of likely values; each value requires
+a separate fingerprint and storage query.
+
 ### Fingerprints Storage
 The default storage, which comes bundled with _soundfingerprinting_ NuGet package, is a plain in-memory storage, available via <code>InMemoryModelService</code> class. If you plan to use an external persistent storage for fingerprints **Emy** is the preferred choice. **Emy** provides a community version which is free for non-commercial use. More about **Emy** can be found [on wiki page][emy-wiki-page].
 

--- a/src/SoundFingerprinting.Tests/Integration/PlaybackSpeedQueryTest.cs
+++ b/src/SoundFingerprinting.Tests/Integration/PlaybackSpeedQueryTest.cs
@@ -1,0 +1,81 @@
+namespace SoundFingerprinting.Tests.Integration
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using SoundFingerprinting.Audio;
+    using SoundFingerprinting.Builder;
+    using SoundFingerprinting.Data;
+    using SoundFingerprinting.InMemory;
+
+    [TestFixture]
+    public class PlaybackSpeedQueryTest : IntegrationWithSampleFilesTest
+    {
+        [TestCase(8d)]
+        [TestCase(-8d)]
+        public async Task CompensatingPlaybackRateShouldRecoverOriginalTrack(double sourcePlaybackSpeedPercentage)
+        {
+            var modelService = new InMemoryModelService();
+            var original = GetAudioSamples();
+            var originalHashes = await FingerprintCommandBuilder.Instance
+                .BuildFingerprintCommand()
+                .From(original)
+                .Hash();
+            modelService.Insert(new TrackInfo("original", "Nocturne", "Chopin"), originalHashes);
+
+            var pitched = Resample(original, 1d + (sourcePlaybackSpeedPercentage / 100d));
+            var uncompensated = await Query(pitched, modelService);
+
+            var recovered = await Query(pitched, sourcePlaybackSpeedPercentage, modelService);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(uncompensated.ContainsMatches, Is.False);
+                Assert.That(recovered.ContainsMatches, Is.True);
+                Assert.That(recovered.BestMatch!.Track.Id, Is.EqualTo("original"));
+                Assert.That(recovered.BestMatch.Confidence, Is.GreaterThan(0.8d));
+            });
+        }
+
+        private static async Task<SoundFingerprinting.Query.QueryResult> Query(
+            AudioSamples samples,
+            InMemoryModelService modelService)
+        {
+            return await Query(samples, null, modelService);
+        }
+
+        private static async Task<SoundFingerprinting.Query.QueryResult> Query(
+            AudioSamples samples,
+            double? sourcePlaybackSpeedPercentage,
+            InMemoryModelService modelService)
+        {
+            var source = QueryCommandBuilder.Instance.BuildQueryCommand();
+            var configured = sourcePlaybackSpeedPercentage.HasValue
+                ? source.From(samples, sourcePlaybackSpeedPercentage.Value)
+                : source.From(samples);
+            var result = await configured
+                .UsingServices(modelService)
+                .Query();
+            return result.Audio!;
+        }
+
+        private static AudioSamples Resample(AudioSamples input, double playbackRate)
+        {
+            int outputLength = System.Math.Max(
+                2,
+                (int)System.Math.Floor((input.Samples.Length - 1) / playbackRate) + 1);
+            float[] output = new float[outputLength];
+            for (int outputIndex = 0; outputIndex < output.Length; outputIndex++)
+            {
+                double sourcePosition = outputIndex * playbackRate;
+                int lowerIndex = System.Math.Min((int)sourcePosition, input.Samples.Length - 1);
+                int upperIndex = System.Math.Min(lowerIndex + 1, input.Samples.Length - 1);
+                double fraction = sourcePosition - lowerIndex;
+                output[outputIndex] = (float)(
+                    input.Samples[lowerIndex] +
+                    ((input.Samples[upperIndex] - input.Samples[lowerIndex]) * fraction));
+            }
+
+            return new AudioSamples(output, input.Origin, input.SampleRate, input.RelativeTo, input.TimeOffset);
+        }
+    }
+}

--- a/src/SoundFingerprinting.Tests/Integration/PlaybackSpeedQueryTest.cs
+++ b/src/SoundFingerprinting.Tests/Integration/PlaybackSpeedQueryTest.cs
@@ -1,11 +1,14 @@
 namespace SoundFingerprinting.Tests.Integration
 {
+    using System;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using SoundFingerprinting.Audio;
     using SoundFingerprinting.Builder;
     using SoundFingerprinting.Data;
     using SoundFingerprinting.InMemory;
+    using SoundFingerprinting.Query;
+    using SoundFingerprinting.Strides;
 
     [TestFixture]
     public class PlaybackSpeedQueryTest : IntegrationWithSampleFilesTest
@@ -36,14 +39,14 @@ namespace SoundFingerprinting.Tests.Integration
             });
         }
 
-        private static async Task<SoundFingerprinting.Query.QueryResult> Query(
+        private static async Task<QueryResult> Query(
             AudioSamples samples,
             InMemoryModelService modelService)
         {
             return await Query(samples, null, modelService);
         }
 
-        private static async Task<SoundFingerprinting.Query.QueryResult> Query(
+        private static async Task<QueryResult> Query(
             AudioSamples samples,
             double? sourcePlaybackSpeedPercentage,
             InMemoryModelService modelService)
@@ -53,6 +56,11 @@ namespace SoundFingerprinting.Tests.Integration
                 ? source.From(samples, sourcePlaybackSpeedPercentage.Value)
                 : source.From(samples);
             var result = await configured
+                .WithQueryConfig(config =>
+                {
+                    config.Audio.Stride = new IncrementalRandomStride(256, 512, seed: 123);
+                    return config;
+                })
                 .UsingServices(modelService)
                 .Query();
             return result.Audio!;
@@ -60,15 +68,15 @@ namespace SoundFingerprinting.Tests.Integration
 
         private static AudioSamples Resample(AudioSamples input, double playbackRate)
         {
-            int outputLength = System.Math.Max(
+            int outputLength = Math.Max(
                 2,
-                (int)System.Math.Floor((input.Samples.Length - 1) / playbackRate) + 1);
+                (int)Math.Floor((input.Samples.Length - 1) / playbackRate) + 1);
             float[] output = new float[outputLength];
             for (int outputIndex = 0; outputIndex < output.Length; outputIndex++)
             {
                 double sourcePosition = outputIndex * playbackRate;
-                int lowerIndex = System.Math.Min((int)sourcePosition, input.Samples.Length - 1);
-                int upperIndex = System.Math.Min(lowerIndex + 1, input.Samples.Length - 1);
+                int lowerIndex = Math.Min((int)sourcePosition, input.Samples.Length - 1);
+                int upperIndex = Math.Min(lowerIndex + 1, input.Samples.Length - 1);
                 double fraction = sourcePosition - lowerIndex;
                 output[outputIndex] = (float)(
                     input.Samples[lowerIndex] +

--- a/src/SoundFingerprinting.Tests/Unit/Audio/PlaybackSpeedAudioSamplesCompensatorTest.cs
+++ b/src/SoundFingerprinting.Tests/Unit/Audio/PlaybackSpeedAudioSamplesCompensatorTest.cs
@@ -1,0 +1,52 @@
+namespace SoundFingerprinting.Tests.Unit.Audio
+{
+    using System;
+    using NUnit.Framework;
+    using SoundFingerprinting.Audio;
+
+    [TestFixture]
+    public class PlaybackSpeedAudioSamplesCompensatorTest
+    {
+        [Test]
+        public void ShouldReturnOriginalSamplesForZeroPlaybackSpeedChange()
+        {
+            var samples = TestUtilities.GenerateRandomAudioSamples(100);
+
+            var compensated = PlaybackSpeedAudioSamplesCompensator.Compensate(samples, 0);
+
+            Assert.That(compensated, Is.SameAs(samples));
+        }
+
+        [TestCase(double.NaN)]
+        [TestCase(double.PositiveInfinity)]
+        [TestCase(double.NegativeInfinity)]
+        [TestCase(double.MaxValue)]
+        [TestCase(-100d)]
+        [TestCase(-101d)]
+        public void ShouldRejectInvalidPlaybackSpeedPercentage(double percentage)
+        {
+            var samples = TestUtilities.GenerateRandomAudioSamples(100);
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => PlaybackSpeedAudioSamplesCompensator.Compensate(samples, percentage));
+        }
+
+        [TestCase(8d, 108)]
+        [TestCase(-8d, 92)]
+        public void ShouldRestoreDurationRepresentedBySourcePlaybackSpeed(double percentage, int expectedLength)
+        {
+            var samples = TestUtilities.GenerateRandomAudioSamples(100);
+
+            var compensated = PlaybackSpeedAudioSamplesCompensator.Compensate(samples, percentage);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(compensated.Samples, Has.Length.EqualTo(expectedLength).Within(1));
+                Assert.That(compensated.SampleRate, Is.EqualTo(samples.SampleRate));
+                Assert.That(compensated.Origin, Is.EqualTo(samples.Origin));
+                Assert.That(compensated.RelativeTo, Is.EqualTo(samples.RelativeTo));
+                Assert.That(compensated.TimeOffset, Is.EqualTo(samples.TimeOffset));
+            });
+        }
+    }
+}

--- a/src/SoundFingerprinting/Audio/PlaybackSpeedAudioSamplesCompensator.cs
+++ b/src/SoundFingerprinting/Audio/PlaybackSpeedAudioSamplesCompensator.cs
@@ -1,0 +1,65 @@
+namespace SoundFingerprinting.Audio
+{
+    using System;
+
+    internal static class PlaybackSpeedAudioSamplesCompensator
+    {
+        public static AudioSamples Compensate(AudioSamples audioSamples, double sourcePlaybackSpeedPercentage)
+        {
+            if (audioSamples == null)
+            {
+                throw new ArgumentNullException(nameof(audioSamples));
+            }
+
+            if (double.IsNaN(sourcePlaybackSpeedPercentage) || double.IsInfinity(sourcePlaybackSpeedPercentage))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(sourcePlaybackSpeedPercentage),
+                    "Playback-speed percentage must be a finite number.");
+            }
+
+            double sourcePlaybackRate = 1d + (sourcePlaybackSpeedPercentage / 100d);
+            if (sourcePlaybackRate <= 0d || double.IsInfinity(sourcePlaybackRate))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(sourcePlaybackSpeedPercentage),
+                    "Playback-speed percentage must produce a finite playback rate greater than zero.");
+            }
+
+            if (Math.Abs(sourcePlaybackSpeedPercentage) < double.Epsilon || audioSamples.Samples.Length < 2)
+            {
+                return audioSamples;
+            }
+
+            double compensationRate = 1d / sourcePlaybackRate;
+            double requestedOutputLength = Math.Floor((audioSamples.Samples.Length - 1) / compensationRate) + 1;
+            if (requestedOutputLength > int.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(sourcePlaybackSpeedPercentage),
+                    "Playback-speed compensation would create too many audio samples.");
+            }
+
+            int outputLength = Math.Max(2, (int)requestedOutputLength);
+            float[] output = new float[outputLength];
+
+            for (int outputIndex = 0; outputIndex < output.Length; outputIndex++)
+            {
+                double sourcePosition = outputIndex * compensationRate;
+                int lowerIndex = Math.Min((int)sourcePosition, audioSamples.Samples.Length - 1);
+                int upperIndex = Math.Min(lowerIndex + 1, audioSamples.Samples.Length - 1);
+                double fraction = sourcePosition - lowerIndex;
+                output[outputIndex] = (float)(
+                    audioSamples.Samples[lowerIndex] +
+                    ((audioSamples.Samples[upperIndex] - audioSamples.Samples[lowerIndex]) * fraction));
+            }
+
+            return new AudioSamples(
+                output,
+                audioSamples.Origin,
+                audioSamples.SampleRate,
+                audioSamples.RelativeTo,
+                audioSamples.TimeOffset);
+        }
+    }
+}

--- a/src/SoundFingerprinting/Builder/QuerySourceExtensions.cs
+++ b/src/SoundFingerprinting/Builder/QuerySourceExtensions.cs
@@ -1,0 +1,42 @@
+namespace SoundFingerprinting.Builder
+{
+    using System;
+    using SoundFingerprinting.Audio;
+    using SoundFingerprinting.Command;
+
+    /// <summary>
+    ///  Extensions for configuring query sources.
+    /// </summary>
+    public static class QuerySourceExtensions
+    {
+        /// <summary>
+        ///   Builds query fingerprints from audio samples captured with a known playback-speed change.
+        /// </summary>
+        /// <param name="source">Query source.</param>
+        /// <param name="audioSamples">Audio samples to build the fingerprints from.</param>
+        /// <param name="sourcePlaybackSpeedPercentage">
+        ///   Playback-speed change applied to the source. For example, pass <c>4</c> when the source
+        ///   was played 4% faster, or <c>-4</c> when it was played 4% slower.
+        /// </param>
+        /// <returns>Configuration selector.</returns>
+        /// <remarks>
+        ///  This compensates vinyl-style pitch control where tempo and pitch change together.
+        ///  It does not compensate pitch-only processing such as key lock.
+        /// </remarks>
+        public static IWithQueryConfiguration From(
+            this IQuerySource source,
+            AudioSamples audioSamples,
+            double sourcePlaybackSpeedPercentage)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var compensated = PlaybackSpeedAudioSamplesCompensator.Compensate(
+                audioSamples,
+                sourcePlaybackSpeedPercentage);
+            return source.From(compensated);
+        }
+    }
+}

--- a/src/SoundFingerprinting/Builder/QuerySourceExtensions.cs
+++ b/src/SoundFingerprinting/Builder/QuerySourceExtensions.cs
@@ -22,6 +22,9 @@ namespace SoundFingerprinting.Builder
         /// <remarks>
         ///  This compensates vinyl-style pitch control where tempo and pitch change together.
         ///  It does not compensate pitch-only processing such as key lock.
+        ///  Since the query is resampled, resulting matches are positioned on the compensated timeline:
+        ///  timestamps relative to the start of the query (i.e., matched at) may deviate from capture
+        ///  wall-clock time by up to <paramref name="sourcePlaybackSpeedPercentage"/> percent.
         /// </remarks>
         public static IWithQueryConfiguration From(
             this IQuerySource source,


### PR DESCRIPTION
## Summary

- add a fluent `From(AudioSamples, sourcePlaybackSpeedPercentage)` extension for regular audio queries
- compensate known vinyl-style playback-speed changes before fingerprinting
- preserve the source sample rate, origin, relative timestamp, and time offset
- document the distinction between speed-plus-pitch changes and pitch-only/key-lock processing
- add validation, resampling unit tests, and real-audio integration coverage for both +8% and -8%

## Why

DJ and vinyl sources often change tempo and pitch together. That produces different fingerprints and can prevent a query from matching the original catalogue entry, as discussed in #217.

When the source playback-speed percentage is known, reciprocal resampling can restore the query close enough to its original playback rate before fingerprinting. This keeps the stored catalogue unchanged. If the percentage is unknown, callers may try a small set of likely values, with one complete fingerprint and storage query per value.

The API is provided as an extension instead of adding a member to `IQuerySource`, avoiding a source-breaking change for third-party implementations.

## Impact

- default query behaviour is unchanged
- no stored fingerprint, model-service, or wire-format changes
- applies to vinyl-style speed changes where tempo and pitch move together
- does not compensate pitch-only processing such as key lock

## Validation

- `dotnet test src\SoundFingerprinting.Tests\SoundFingerprinting.Tests.csproj --no-restore --filter "FullyQualifiedName~SoundFingerprinting.Tests.Unit.Audio|FullyQualifiedName~PlaybackSpeedQueryTest|FullyQualifiedName~QueryCommandBuilderTest"` — 79 passed
- `dotnet build src\SoundFingerprinting\SoundFingerprinting.csproj --configuration Release --no-restore` — succeeded
